### PR TITLE
added timesheet display

### DIFF
--- a/src/commands/log/mod.ts
+++ b/src/commands/log/mod.ts
@@ -162,17 +162,17 @@ function printTimesheet(sessions: Session[]) {
     sessions.forEach((session) => {
         let start = new Date(session.start);
         let end = new Date(session.end ? session.end : Date.now());
-        const [startyear, startmonth, startdate] = destructureDate(start);
-        const [endyear, endmonth, enddate] = destructureDate(end);
+        const [startYear, startMonth, startDate] = destructureDate(start);
+        const [endYear, endMonth, endDate] = destructureDate(end);
 
         const updateBucket = (key: number, val: number) => {
             let prevVal = buckets.get(key) || 0;
             buckets.set(key, Math.min(prevVal + val, 24 * 60 * 60 * 1000));
         };
 
-        if (startdate === enddate) {
+        if (startDate === endDate) {
             // session does not spill into another day
-            const key = new Date(startyear, startmonth - 1, startdate).getTime();
+            const key = new Date(startYear, startMonth - 1, startDate).getTime();
             let hours = end.getTime() - start.getTime();
             updateBucket(key, hours);
         } else {

--- a/src/commands/log/mod.ts
+++ b/src/commands/log/mod.ts
@@ -2,7 +2,7 @@ import { Command } from "@/commander";
 import { Table } from "@/cliffy/table";
 import * as storage from "../../storage.ts";
 import { match } from "@/oxide";
-import { getProjectId, heading, humanReadable, muted, scream, Session, sessionName, timeMs } from "../../utils.ts";
+import { getProjectId, heading, humanReadable, msToTime, muted, scream, Session, sessionName, timeMs } from "../../utils.ts";
 import { success } from "../../utils.ts";
 
 interface ESummaryOpts {
@@ -197,20 +197,16 @@ function printTimesheet(sessions: Session[]) {
     });
 
     table.push([heading("Month"), heading("Date"), heading("Hours Logged")]);
-    let current_month = -1;
+    let currentMonth = -1;
 
     buckets.forEach((millis, key) => {
-        let bucket_date = new Date(key)
-        let month_string = "";
-        if (current_month != bucket_date.getMonth() - 1) {
-            current_month = bucket_date.getMonth() - 1;
-            month_string = new Intl.DateTimeFormat("en-GB", {month: "long"}).format(bucket_date)
+        let bucketDate = new Date(key)
+        let monthString = "";
+        if (currentMonth != bucketDate.getMonth() - 1) {
+            currentMonth = bucketDate.getMonth() - 1;
+            monthString = new Intl.DateTimeFormat("en-GB", {month: "long"}).format(bucketDate)
         }
-        const minutes  = Math.floor(millis / 1000 / 60);
-        const hours = Math.floor(minutes / 60);
-        const seconds =
-            Math.floor(millis / 1000) - minutes * 60;
-        table.push([month_string, heading(new Intl.DateTimeFormat("en-GB").format(bucket_date)), success(`${hours}h ${minutes - hours * 60}m ${seconds}s`)]);
+        table.push([monthString, heading(new Intl.DateTimeFormat("en-GB").format(bucketDate)), success(humanReadable(millis, true))]);
     });
 
     Table.from(table).border(true).render();


### PR DESCRIPTION
Sessions can be visualized as timesheets now.

### In Action
---
![image](https://github.com/user-attachments/assets/d48f978f-ce30-4be0-bf96-beed21e7b426)

### Updated Help Section
---
![image](https://github.com/user-attachments/assets/8ebb7e2f-017d-4aa3-a558-d5bdd17dfb09)


Would be better to display the timesheet for the current and previous month only as the database gets bigger, but that's work for the future
